### PR TITLE
[BUGFIX] Make sure socket is closed before retrying in _wait_ssh

### DIFF
--- a/fastec2/ec2.py
+++ b/fastec2/ec2.py
@@ -324,13 +324,13 @@ class EC2():
 
     def _wait_ssh(self, inst):
         self.waitfor('instance', 'running', inst.id)
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            for i in range(720//5):
-                try:
+        for i in range(720//5):
+            try:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                     s.connect((inst.public_ip_address, 22))
                     time.sleep(1)
-                    return inst
-                except (ConnectionRefusedError,BlockingIOError): time.sleep(5)
+                return inst
+            except (ConnectionRefusedError,BlockingIOError): time.sleep(5)
 
     def get_launch(self, name, ami, disksize, instancetype, keyname:str='default', secgroupname:str='ssh',
                    iops:int=None, spot:bool=False):


### PR DESCRIPTION
When launching an instance, I was routinely getting the exception below.  Docs and googling suggested that this can happen if the socket is still open and you try to bind/connect twice. 

This change simply moves the opening of the socket with the context manager inside the loop so that it is closed upon exception before retrying.  Instantly solved the problem for me. 

```
Traceback (most recent call last):
  File "/Users/mdagostino/.pyenv/versions/fe2/bin/fe2", line 11, in <module>
    load_entry_point('fastec2==1.0.0', 'console_scripts', 'fe2')()
  File "/Users/mdagostino/.pyenv/versions/fe2/lib/python3.6/site-packages/fastec2/__init__.py", line 9, in main
    else: fire.Fire(EC2)
  File "/Users/mdagostino/.pyenv/versions/fe2/lib/python3.6/site-packages/fire/core.py", line 127, in Fire
    component_trace = _Fire(component, args, context, name)
  File "/Users/mdagostino/.pyenv/versions/fe2/lib/python3.6/site-packages/fire/core.py", line 366, in _Fire
    component, remaining_args)
  File "/Users/mdagostino/.pyenv/versions/fe2/lib/python3.6/site-packages/fire/core.py", line 542, in _CallCallable
    result = fn(*varargs, **kwargs)
  File "/Users/mdagostino/.pyenv/versions/fe2/lib/python3.6/site-packages/fastec2/ec2.py", line 357, in launch
    print(self.get_launch(name, ami, disksize, instancetype, keyname, secgroupname, iops, spot))
  File "/Users/mdagostino/.pyenv/versions/fe2/lib/python3.6/site-packages/fastec2/ec2.py", line 349, in get_launch
    self._wait_ssh(inst)
  File "/Users/mdagostino/.pyenv/versions/fe2/lib/python3.6/site-packages/fastec2/ec2.py", line 330, in _wait_ssh
    s.connect((inst.public_ip_address, 22))
OSError: [Errno 22] Invalid argument
```