### PR TITLE
Fix typo in help string of terminate

### DIFF
--- a/fastec2/ec2.py
+++ b/fastec2/ec2.py
@@ -372,7 +372,7 @@ class EC2():
         else: return inst
 
     def terminate(self, inst):
-        "Starts instance `inst`"
+        "Terminates instance `inst`"
         inst = self.get_instance(inst)
         sr = SpotRequest.from_instance(self, inst)
         if sr is not None: sr.cancel()


### PR DESCRIPTION
Hi, thanks for your great tool!
I just stumbled across this typo when using: `fe2 terminate --help`